### PR TITLE
Exclude snapshot file in swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -72,6 +72,7 @@ excluded:
   - Pods/
   - vendor/bundle/
   - Kwartracker/API.swift
+  - fastlane/SnapshotHelper.swift
 reporter: "xcode"
 custom_rules:
   localized_lensing:


### PR DESCRIPTION
# 📲 What
- Exclude SnapshotHelper.swift from reporting warnings.

# 🤔 Why
- Warnings in SnapshotHelper.swift shows.

# 🛠 How
- N/A

# ✅ Acceptance criteria
- N/A

# ⏰ TODO
- N/A

# 🔗 References
- N/A